### PR TITLE
Fix some typos and formatting errors

### DIFF
--- a/en/docs/tester/index.html
+++ b/en/docs/tester/index.html
@@ -487,7 +487,7 @@ The outcome can be exactly one of:</p>
 <ul>
 <li>
 <p><a class="gl-ref" href="../glossary/#pass_test" markdown="1">Pass</a>:
-    the test works as expected.</p>
+    the test subject works as expected.</p>
 </li>
 <li>
 <p><a class="gl-ref" href="../glossary/#fail_test" markdown="1">Fail</a>:
@@ -495,7 +495,7 @@ The outcome can be exactly one of:</p>
 </li>
 <li>
 <p><a class="gl-ref" href="../glossary/#error_test" markdown="1">Error</a>:
-    something wrong in the test itself,
+    something is wrong in the test itself,
     which means we don&rsquo;t know whether the test subject is working properly or not.</p>
 </li>
 </ul>
@@ -504,7 +504,7 @@ we need some way to distinguish failing tests from broken ones.
 Our solution relies on the fact that exceptions are objects
 and that a program can use <a class="gl-ref" href="../glossary/#introspection" markdown="1">introspection</a>
 to determine the class of an object.
-If a test <a class="gl-ref" href="../glossary/#throw_exception" markdown="1">throws an exception</a> whose class is <code>assert.AssertionError</code>,
+If a test <a class="gl-ref" href="../glossary/#throw_exception" markdown="1">throws an exception</a> whose class is <code>AssertionError</code>,
 then we will assume the exception came from
 one of the assertions we put in the test as a check.
 Any other kind of assertion indicates that the test itself contains an error.</p>
@@ -524,7 +524,7 @@ in an array:</p>
     <span class="n">HOPE_TESTS</span><span class="o">.</span><span class="n">append</span><span class="p">([</span><span class="n">message</span><span class="p">,</span> <span class="n">func</span><span class="p">])</span>
 </code></pre></div>
 </div>
-<blockquote>
+<div class="callout">
 <h3>Independence</h3>
 <p>Because we&rsquo;re appending tests to an array,
 they will be run in the order in which they are registered,
@@ -532,7 +532,7 @@ but we shouldn&rsquo;t rely on that.
 Every unit test should work independently of every other
 so that an error or failure in an early test
 doesn&rsquo;t affect the result of a later one.</p>
-</blockquote>
+</div>
 <p>The function <code>main</code> runs all registered tests:</p>
 <div class="code-sample lang-py" title="dry_run.py">
 <div class="highlight"><pre><span></span><code><span class="c1"># Run all of the tests that have been asked for and report summary.</span>

--- a/en/src/tester/index.md
+++ b/en/src/tester/index.md
@@ -263,13 +263,13 @@ against the [%g expected_result "expected result" %].
 The outcome can be exactly one of:
 
 -   [%g pass_test "Pass" %]:
-    the test works as expected.
+    the test subject works as expected.
 
 -   [%g fail_test "Fail" %]:
     something is wrong with the test subject.
 
 -   [%g error_test "Error" %]:
-    something wrong in the test itself,
+    something is wrong in the test itself,
     which means we don't know whether the test subject is working properly or not.
 
 To make this work,
@@ -277,7 +277,7 @@ we need some way to distinguish failing tests from broken ones.
 Our solution relies on the fact that exceptions are objects
 and that a program can use [%g introspection "introspection" %]
 to determine the class of an object.
-If a test [%g throw_exception "throws an exception" %] whose class is `assert.AssertionError`,
+If a test [%g throw_exception "throws an exception" %] whose class is `AssertionError`,
 then we will assume the exception came from
 one of the assertions we put in the test as a check.
 Any other kind of assertion indicates that the test itself contains an error.
@@ -292,14 +292,18 @@ in an array:
 
 [% inc file="dry_run.py" keep="save" %]
 
-> ### Independence
->
-> Because we're appending tests to an array,
-> they will be run in the order in which they are registered,
-> but we shouldn't rely on that.
-> Every unit test should work independently of every other
-> so that an error or failure in an early test
-> doesn't affect the result of a later one.
+<div class="callout" markdown="1">
+
+### Independence
+
+Because we're appending tests to an array,
+they will be run in the order in which they are registered,
+but we shouldn't rely on that.
+Every unit test should work independently of every other
+so that an error or failure in an early test
+doesn't affect the result of a later one.
+
+</div>
 
 The function `main` runs all registered tests:
 


### PR DESCRIPTION
Greg, I don't know if you want to keep the same structure defined in sdxjs. If so, in future PRs I can also add some common (regarding that they appear both in sdxjs and sdxpy) definition terms to the glossary, such as _test runner_, _test subject_, etc., that are missing in sdxpy (but that perfectly fit here). The same applies to the figures. I can help in that front too.