### PR TITLE
Fix typo. Fix 404 in pyfakefs

### DIFF
--- a/en/src/server/index.md
+++ b/en/src/server/index.md
@@ -505,7 +505,7 @@ Modify the file server so that:
 
 ### Better content types {: .exercise}
 
-Read the documentation for the [mimtypes][py_mimetypes] module
+Read the documentation for the [mimetypes][py_mimetypes] module
 and then modify the file server to return the correct content type
 for files that aren't HTML (such as images).
 

--- a/info/links.yml
+++ b/info/links.yml
@@ -257,7 +257,7 @@
   url: https://docs.python.org/3/library/urllib.parse.html
   en: Python URL parsing
 - key: pyfakefs
-  url: https://jmcgeheeiv.github.io/pyfakefs/
+  url: https://pytest-pyfakefs.readthedocs.io/en/latest/
   en: pyfakefs module
 - key: pyparsing
   url: https://pyparsing-docs.readthedocs.io/


### PR DESCRIPTION
I know that this is a WIP but I was curious about the server chapter and couldn't resist the temptation :)

I was also wondering if this sentence:
"Ports 0-1023 are reserved for the operating system's use; anyone else can use the remaining ports."
could be more precise rewriting it as:
"Ports 0-1023 are reserved for common -well-known- TCP/IP applications; it is recommended to use the remaining ports for any other custom application"

Feel free to throw it in /dev/null