### PR TITLE
Fix bug: argument of type 'NoneType' is not iterable

### DIFF
--- a/en/docs/tester/docstring.out
+++ b/en/docs/tester/docstring.out
@@ -1,4 +1,4 @@
 skip: test_sign_negative
-error: test_sign_positive argument of type 'NoneType' is not iterable
+pass: test_sign_positive
 pass (expected failure): test_sign_zero
 error: test_sign_error/Expect an error. name 'sgn' is not defined

--- a/en/docs/tester/docstring.py
+++ b/en/docs/tester/docstring.py
@@ -30,7 +30,7 @@ def run_tests(prefix):
     for name in prefixed_names:
         func = globals()[name]
         try:
-            if TEST_SKIP in func.__doc__:
+            if func.__doc__ and TEST_SKIP in func.__doc__:
                 print(f"skip: {name}")
             else:
                 func()

--- a/en/docs/tester/index.html
+++ b/en/docs/tester/index.html
@@ -690,7 +690,7 @@ Let&rsquo;s rewrite our tests to show this off:</p>
     <span class="k">for</span> <span class="n">name</span> <span class="ow">in</span> <span class="n">prefixed_names</span><span class="p">:</span>
         <span class="n">func</span> <span class="o">=</span> <span class="nb">globals</span><span class="p">()[</span><span class="n">name</span><span class="p">]</span>
         <span class="k">try</span><span class="p">:</span>
-            <span class="k">if</span> <span class="n">TEST_SKIP</span> <span class="ow">in</span> <span class="n">func</span><span class="o">.</span><span class="vm">__doc__</span><span class="p">:</span>
+            <span class="k">if</span> <span class="n">func</span><span class="o">.</span><span class="vm">__doc__</span> <span class="ow">and</span> <span class="n">TEST_SKIP</span> <span class="ow">in</span> <span class="n">func</span><span class="o">.</span><span class="vm">__doc__</span><span class="p">:</span>
                 <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;skip: </span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
             <span class="k">else</span><span class="p">:</span>
                 <span class="n">func</span><span class="p">()</span>
@@ -710,7 +710,7 @@ Let&rsquo;s rewrite our tests to show this off:</p>
 <p>The output is now:</p>
 <div class="code-sample lang-out" title="docstring.out">
 <div class="highlight"><pre><span></span><code>skip: test_sign_negative
-error: test_sign_positive argument of type &#39;NoneType&#39; is not iterable
+pass: test_sign_positive
 pass (expected failure): test_sign_zero
 error: test_sign_error/Expect an error. name &#39;sgn&#39; is not defined
 </code></pre></div>
@@ -804,7 +804,7 @@ that can be &ldquo;called&rdquo; just like functions.
 If an object <code>obj</code> has a <code>__call__</code> method,
 then <code>obj(…)</code> is automatically turned into <code>obj.__call__(…)</code>.
 For example,
-the code below defines a class <code>Adder</code> whose instances add a constant to ther input:</p>
+the code below defines a class <code>Adder</code> whose instances add a constant to their input:</p>
 <div class="code-sample lang-py" title="callable.py">
 <div class="highlight"><pre><span></span><code><span class="k">class</span> <span class="nc">Adder</span><span class="p">:</span>
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">value</span><span class="p">):</span>
@@ -918,7 +918,7 @@ As a result,
 any test that <em>doesn&rsquo;t</em> replace <code>adder</code> will run with
 whatever mock object was last put in place
 rather than with the original <code>adder</code> function.</p>
-<p>We could tell users it&rsquo;s their job to put everthing back after each test,
+<p>We could tell users it&rsquo;s their job to put everything back after each test,
 but people are forgetful.
 It would be better if Python did this automatically;
 luckily for us,

--- a/en/src/tester/docstring.out
+++ b/en/src/tester/docstring.out
@@ -1,4 +1,4 @@
 skip: test_sign_negative
-error: test_sign_positive argument of type 'NoneType' is not iterable
+pass: test_sign_positive
 pass (expected failure): test_sign_zero
 error: test_sign_error/Expect an error. name 'sgn' is not defined

--- a/en/src/tester/docstring.py
+++ b/en/src/tester/docstring.py
@@ -30,7 +30,7 @@ def run_tests(prefix):
     for name in prefixed_names:
         func = globals()[name]
         try:
-            if TEST_SKIP in func.__doc__:
+            if func.__doc__ and TEST_SKIP in func.__doc__:
                 print(f"skip: {name}")
             else:
                 func()


### PR DESCRIPTION
Trying to iterate over `func.__doc__` will yield an error when the docstring is missing:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/1078305/205940904-e8789bd3-5c6a-4dd0-9fd5-19988a4a6e87.png">

So this test will err (when it should pass):
<img width="451" alt="image" src="https://user-images.githubusercontent.com/1078305/205941454-319642c8-1461-4308-aa44-db713068c6a5.png">

PD: I would also take a look at consistency with respect to the use of docstring quotes. The last test (`test_sign_error`) is using a triple double quote while the previous ones are using single double quotes.
