### PR TITLE
Binary chapter: Add support for correctly typesetting Python binary operators in LaTeX

### DIFF
--- a/bin/html2tex.py
+++ b/bin/html2tex.py
@@ -78,6 +78,7 @@ def escape(text, doEscape):
         .replace("^", r"{\textasciicircum}")
         .replace("#", r"\#")
         .replace("&", r"\&")
+        .replace("~", r"{\textapprox}") # see https://tex.stackexchange.com/a/377
         .replace("©", r"{\textcopyright}")
         .replace("μ", r"{\textmu}")
         .replace("…", "...")

--- a/bin/html2tex.py
+++ b/bin/html2tex.py
@@ -78,6 +78,10 @@ def escape(text, doEscape):
         .replace("^", r"{\textasciicircum}")
         .replace("#", r"\#")
         .replace("&", r"\&")
+        .replace("<<<", r"<\null<\null<")
+        .replace(">>>", r">\null>\null>")
+        .replace("<<", r"<\null<")
+        .replace(">>", r">\null>")
         .replace("~", r"{\textapprox}") # see https://tex.stackexchange.com/a/377
         .replace("©", r"{\textcopyright}")
         .replace("μ", r"{\textmu}")

--- a/docs/binary/bit_mask.py
+++ b/docs/binary/bit_mask.py
@@ -1,2 +1,2 @@
-mask = ~0x0100  # binary 1111 1110 1111 1111
+mask = ~0x0100    # binary 1111 1110 1111 1111
 val = val & mask  #    clears this ^ bit

--- a/docs/binary/index.html
+++ b/docs/binary/index.html
@@ -548,10 +548,10 @@ create a <a class="gl-ref" href="../glossary/#bit_mask" markdown="1">mask</a> in
 then use <code>&amp;</code> to combine the two.
 To make things easier to read,
 programmers often set a single bit,
-negative it with <code>~</code>,
+negate it with <code>~</code>,
 and then use <code>&amp;</code>:</p>
 <div class="code-sample lang-py" title="bit_mask.py">
-<div class="highlight"><pre><span></span><code><span class="n">mask</span> <span class="o">=</span> <span class="o">~</span><span class="mh">0x0100</span>  <span class="c1"># binary 1111 1110 1111 1111</span>
+<div class="highlight"><pre><span></span><code><span class="n">mask</span> <span class="o">=</span> <span class="o">~</span><span class="mh">0x0100</span>    <span class="c1"># binary 1111 1110 1111 1111</span>
 <span class="n">val</span> <span class="o">=</span> <span class="n">val</span> <span class="o">&amp;</span> <span class="n">mask</span>  <span class="c1">#    clears this ^ bit</span>
 </code></pre></div>
 </div>

--- a/en/src/binary/bit_mask.py
+++ b/en/src/binary/bit_mask.py
@@ -1,2 +1,2 @@
-mask = ~0x0100  # binary 1111 1110 1111 1111
+mask = ~0x0100    # binary 1111 1110 1111 1111
 val = val & mask  #    clears this ^ bit

--- a/en/src/binary/index.md
+++ b/en/src/binary/index.md
@@ -140,7 +140,7 @@ create a [%g bit_mask "mask" %] in which that bit is 0 and the others are 1,
 then use `&` to combine the two.
 To make things easier to read,
 programmers often set a single bit,
-negative it with `~`,
+negate it with `~`,
 and then use `&`:
 
 [% inc file="bit_mask.py" %]

--- a/info/head.tex
+++ b/info/head.tex
@@ -41,6 +41,8 @@
 % \usepackage[showframe]{geometry}
 % \usepackage{geometry}
 \usepackage{textcomp}
+\newcommand{\textapprox}{\raisebox{0.5ex}{\texttildelow}}
+
 
 % Some special symbols.
 \usepackage{amssymb}


### PR DESCRIPTION
Add support for correctly typesetting a tilde (not operator in Python) and  >>,>>>,<<,<<< symbols (shift operators in Python) in LaTeX.
Fix a couple of typos.
