### PR TITLE
Fix LaTeX Error: Command \textapprox unavailable in encoding T1

### DIFF
--- a/info/head.tex
+++ b/info/head.tex
@@ -41,7 +41,7 @@
 % \usepackage[showframe]{geometry}
 % \usepackage{geometry}
 \usepackage{textcomp}
-\newcommand{\textapprox}{\raisebox{0.5ex}{\texttildelow}}
+\DeclareTextCommand{\textapprox}{T1}{\raisebox{0.5ex}{\texttildelow}}
 
 
 % Some special symbols.


### PR DESCRIPTION
This is strange. I don't know why this command in `info/head.tex`:
`\newcommand{\textapprox}{\raisebox{0.5ex}{\texttildelow}}`
was working in my lab's computer (where I have a TeX 2019 version IIRC) but fails with this error: 
`LaTeX Error: Command \textapprox unavailable in encoding T1` in my home's computer (where I have a TeX 2022 version)
```
$ pdflatex -version
pdfTeX 3.141592653-2.6-1.40.24 (TeX Live 2022)
kpathsea version 6.3.4
````
So I replaced the previous command with this one:
`\DeclareTextCommand{\textapprox}{T1}{\raisebox{0.5ex}{\texttildelow}}`
and now it works like a charm in TeX 2022 but, will it also work in TeX 2021? I'll double check it tomorrow morning.