### PR TITLE
Fix Typos

### DIFF
--- a/docs/binary/index.html
+++ b/docs/binary/index.html
@@ -768,7 +768,7 @@ but if we&rsquo;re going to process the data many times,
 it makes sense to avoid paying the conversion cost over and over.</dd>
 <dt>Hardware</dt>
 <dd>Someone, somewhere, has to convert the signal from the thermocouple to a number,
-and that signal probably arrives arrives as a stream of 1&rsquo;s and 0&rsquo;s.</dd>
+and that signal probably arrives as a stream of 1&rsquo;s and 0&rsquo;s.</dd>
 <dt>Lack of anything better</dt>
 <dd>It&rsquo;s possible to represent images as ASCII art, but sound?
 Or video?
@@ -809,7 +809,7 @@ on the other hand,
 put each value in a data structure
 that keeps track of its type along with a bit of extra administrative information
 (<a class="fig-ref" href="../binary/#binary-boxing">Figure 7.2</a>).
-Something stored this was is called a <a class="gl-ref" href="../glossary/#boxed_value" markdown="1">boxed value</a>;
+Something stored this way is called a <a class="gl-ref" href="../glossary/#boxed_value" markdown="1">boxed value</a>;
 this extra data allows the language to do <a class="gl-ref" href="../glossary/#introspection" markdown="1">introspection</a>,
 <a class="gl-ref" href="../glossary/#garbage_collection" markdown="1">garbage collection</a>,
 and much more.</p>
@@ -898,11 +898,11 @@ back to normal: (31, 65)
 If Python finds a character in a string that doesn&rsquo;t have a printable representation,
 it prints a 2-digit escape sequence in <a class="gl-ref" href="../glossary/#hexadecimal" markdown="1">hexadecimal</a> (base 16).
 This uses the letters A-F (or a-f) to represent the digits from 10 to 15,
-so that (for example) <code>3D5</code> is (3×16^2^)+(13×16^1^)+(5×16^0^), or 981 in decimal.
+so that (for example) <code>3D5</code> is (3×16^2)+(13×16^1)+(5×16^0), or 981 in decimal.
 Python is therefore telling us that
 our string contains the eight bytes
 <code>['\x1f', '\x00', '\x00', '\x00', 'A', '\x00', '\x00', '\x00']</code>.
-<code>1F</code> in hex is (1×16^1^)+(15×16^0^), or 31;
+<code>1F</code> in hex is (1×16^1)+(15×16^0), or 31;
 <code>'A'</code> is our 65,
 because the ASCII code for an upper-case letter A is the decimal value 65.
 All the other bytes are zeroes (<code>"\x00"</code>)
@@ -985,7 +985,7 @@ which just happens to be exactly the right format to use to pack it.</p>
 <p>That&rsquo;s fine when we&rsquo;re writing,
 but how do we know how much data to get if we&rsquo;re reading?
 For example, suppose we have the two strings &ldquo;hello&rdquo; and &ldquo;Python&rdquo;.
-we can pack them like this:</p>
+We can pack them like this:</p>
 <div class="highlight"><pre><span></span><code><span class="n">pack</span><span class="p">(</span><span class="s1">&#39;5s6s&#39;</span><span class="p">,</span> <span class="s1">&#39;hello&#39;</span><span class="p">,</span> <span class="s1">&#39;Python&#39;</span><span class="p">)</span>
 </code></pre></div>
 <p class="continue">but how do I know how to unpack 5 characters then 6?
@@ -1054,7 +1054,7 @@ There are pro&rsquo;s and con&rsquo;s to both, which we won&rsquo;t go into here
 What you <em>do</em> need to know is that if you move data from one architecture to another,
 it&rsquo;s your responsibility to flip the bytes around,
 because the machine doesn&rsquo;t know what the bytes mean.
-This is such a pain that the <code>struct</code> library and other libraries like
+This is such a pain that the <code>struct</code> library and other libraries like it 
 will do things for you if you ask it to.
 If you&rsquo;re using <code>struct</code>,
 the first character of a format string optionally indicates the byte order

--- a/en/src/binary/index.md
+++ b/en/src/binary/index.md
@@ -504,11 +504,11 @@ What is `\x1f` and why is it in our data?
 If Python finds a character in a string that doesn't have a printable representation,
 it prints a 2-digit escape sequence in [%g hexadecimal "hexadecimal" %] (base 16).
 This uses the letters A-F (or a-f) to represent the digits from 10 to 15,
-so that (for example) `3D5` is (3×16^2^)+(13×16^1^)+(5×16^0^), or 981 in decimal.
+so that (for example) `3D5` is (3×16^2)+(13×16^1)+(5×16^0), or 981 in decimal.
 Python is therefore telling us that
 our string contains the eight bytes
 `['\x1f', '\x00', '\x00', '\x00', 'A', '\x00', '\x00', '\x00']`.
-`1F` in hex is (1×16^1^)+(15×16^0^), or 31;
+`1F` in hex is (1×16^1)+(15×16^0), or 31;
 `'A'` is our 65,
 because the ASCII code for an upper-case letter A is the decimal value 65.
 All the other bytes are zeroes (`"\x00"`)

--- a/en/src/binary/index.md
+++ b/en/src/binary/index.md
@@ -380,7 +380,7 @@ Speed
 
 Hardware
 :   Someone, somewhere, has to convert the signal from the thermocouple to a number,
-    and that signal probably arrives arrives as a stream of 1's and 0's.
+    and that signal probably arrives as a stream of 1's and 0's.
     
 Lack of anything better
 :   It's possible to represent images as ASCII art, but sound?
@@ -420,7 +420,7 @@ on the other hand,
 put each value in a data structure
 that keeps track of its type along with a bit of extra administrative information
 ([%f binary-boxing %]).
-Something stored this was is called a [%g boxed_value "boxed value" %];
+Something stored this way is called a [%g boxed_value "boxed value" %];
 this extra data allows the language to do [%g introspection "introspection" %],
 [%g garbage_collection "garbage collection" %],
 and much more.
@@ -564,7 +564,7 @@ which just happens to be exactly the right format to use to pack it.
 That's fine when we're writing,
 but how do we know how much data to get if we're reading?
 For example, suppose we have the two strings "hello" and "Python".
-we can pack them like this:
+We can pack them like this:
 
 ```python
 pack('5s6s', 'hello', 'Python')
@@ -601,7 +601,7 @@ There are pro's and con's to both, which we won't go into here.
 What you *do* need to know is that if you move data from one architecture to another,
 it's your responsibility to flip the bytes around,
 because the machine doesn't know what the bytes mean.
-This is such a pain that the `struct` library and other libraries like
+This is such a pain that the `struct` library and other libraries like it 
 will do things for you if you ask it to.
 If you're using `struct`,
 the first character of a format string optionally indicates the byte order


### PR DESCRIPTION
I'm not sure about the fix related to the exponentials. I mean, I'm not aware of this way of writing exponentials: `3×16^2^` (I think that the last circumflex accent could be removed)  but that notation is repeated 5 times so it seems that I might be wrong. That's why I added the "Fix exponentials" as a separate commit so you can cherry-pick the others.