### PR TITLE
Fix reference borrowed from sdxjs

### DIFF
--- a/docs/builder/index.html
+++ b/docs/builder/index.html
@@ -974,7 +974,7 @@ while child classes implement those operations without changing the flow of cont
 We have added a lot of steps to our original template method,
 which makes it a bit of a stretch to claim that the overall operation hasn&rsquo;t changed.
 Knowing what we know now,
-we could go back and modify the original <code>SkeletonBuilder.build</code> method
+we could go back and modify the original <code>ConfigLoader.build</code> method
 to include those extra steps and provide do-nothing implementations.</p>
 <p>The root of the problem is that we didn&rsquo;t anticipate all the steps that would be involved
 when we wrote our template method.

--- a/en/src/builder/index.md
+++ b/en/src/builder/index.md
@@ -378,7 +378,7 @@ while child classes implement those operations without changing the flow of cont
 We have added a lot of steps to our original template method,
 which makes it a bit of a stretch to claim that the overall operation hasn't changed.
 Knowing what we know now,
-we could go back and modify the original `SkeletonBuilder.build` method
+we could go back and modify the original `ConfigLoader.build` method
 to include those extra steps and provide do-nothing implementations.
 
 The root of the problem is that we didn't anticipate all the steps that would be involved


### PR DESCRIPTION
Apart from the fix, I'm not sure if the Template Method discussion fully applies to this chapter. In sdxjs the **SkeletonBuilder.build** method defined a set of instructions (pattern) to follow  by the child classes:
```
this.loadConfig() 
this.buildGraph() 
this.checkCycles() 
this.run()
```
but in sdxpy the class **ConfigLoader.build** just defines a _build_ method -with a single step _self.load_config_- that has been overriden by its child classes, adding many other methods where the flow of control could be changed. Even though the flow didn't change, there was nothing impeding it. 