### PR TITLE
Matching patterns: Fix typo

### DIFF
--- a/docs/matching/index.html
+++ b/docs/matching/index.html
@@ -252,7 +252,7 @@
   
   <ul class="syllabus">
   
-  <li markdown="1">Use regular expressions to match patterns in text and extra data.</li>
+  <li markdown="1">Use regular expressions to match patterns in text and extract data.</li>
   
   <li markdown="1">Use inheritance to make matchers composable and extensible.</li>
   

--- a/docs/syllabus/index.html
+++ b/docs/syllabus/index.html
@@ -374,7 +374,7 @@
 </li>
 <li><a href="../matching" markdown="1">Matching Patterns</a>
 <ul>
-<li markdown="1">Use regular expressions to match patterns in text and extra data.</li>
+<li markdown="1">Use regular expressions to match patterns in text and extract data.</li>
 <li markdown="1">Use inheritance to make matchers composable and extensible.</li>
 <li markdown="1">Objects can delegate work to other objects using the Chain of Responsibility pattern.</li>
 </ul>

--- a/en/src/matching/index.md
+++ b/en/src/matching/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Matching Patterns"
 syllabus:
-- Use regular expressions to match patterns in text and extra data.
+- Use regular expressions to match patterns in text and extract data.
 - Use inheritance to make matchers composable and extensible.
 - Objects can delegate work to other objects using the Chain of Responsibility pattern.
 ---


### PR DESCRIPTION
"Extract data" makes more sense than "extra data", but it could be the other way around...