### PR TITLE
Fix output of dot notation example.

### DIFF
--- a/en/src/tester/slides/index.html
+++ b/en/src/tester/slides/index.html
@@ -232,7 +232,7 @@ dir("hello")
 "hello".title()
 ```
 ```
-Title
+Hello
 ```
 
 ---


### PR DESCRIPTION
The dot notation example uses the string object's title method as a demonstration. This returns the string formatted into title case.

The output on the slides was the word title in title case. Changed to hello.