### PR TITLE
Remove prefix in run_tests call

### DIFF
--- a/en/src/tester/slides/index.html
+++ b/en/src/tester/slides/index.html
@@ -450,7 +450,7 @@ def run_tests():
 ## A Better (?) Test Runner
 
 ```python
-run_tests("test_")
+run_tests()
 ```
 ```
 skip: test_sign_negative


### PR DESCRIPTION
After changing run_tests to not use a prefix, the call which originally used a prefix needs to be updated.