### PR TITLE
Fix index.html typo

### DIFF
--- a/docs/tester/slides/index.html
+++ b/docs/tester/slides/index.html
@@ -466,7 +466,7 @@ def run_tests():
         if not name.startswith("test_"):
             continue
 
-        if hasattr(func, "skip")
+        if hasattr(func, "skip"):
             print(f"skip: {name}")
             continue
 


### PR DESCRIPTION
add `:` to `if hasattr(func, "skip")`