### PR TITLE
fix #201

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .idea
 .pytest_cache
+.vscode
 __pycache__
 all.html
 **/docs/*.aux

--- a/src/parse/match.py
+++ b/src/parse/match.py
@@ -4,9 +4,9 @@ class Match:
         self.rest = rest if rest else Null()
 
     def __eq__(self, other):
-        return (other is not None) and (
-            self.__class__ == other.__class__
-        )
+        return (other is not None and 
+                self.__class__ == other.__class__ and 
+                self.rest == other.rest)
 
 class Lit(Match):
     def __init__(self, chars, rest=None):


### PR DESCRIPTION
Additional `self.rest == other.rest` test is added so not only root object is checked.
This change causes the false positive mentioned in issue to fail, which is desired.
This change still passes all existing tests.
This extra test terminates the __eq__ recursion when self is the final Null() object, and the final check is `self.rest == other.rest`  compares `None == None`

Notes:
1. Bracketing patterns were changed because it seems the intention was to use brackets only for line continuation, in which case a single pair is sufficient
2. One condition per line for convenient stepping through using "debug inline values" vscode setting during debugging

Questions:
1. Inconsistency in the `__eq__` implementation of `Either` subclass. 
   `self.children.__eq__(other.children)` was used, but less verbose `self.children == other.children` would have sufficed, 
   to be consistent with `self.__class__ == other.__class__` (`Match`) and `self.chars == other.chars` (`Lit`)