### PR TITLE
Fixes CH4 test missed match call

### DIFF
--- a/src/glob/test_glob_problem.py
+++ b/src/glob/test_glob_problem.py
@@ -4,9 +4,9 @@ from glob_either import Either
 # [keep]
 def test_either_followed_by_literal_match():
     # /{a,b}c/ matches "ac"
-    assert Either(Lit("a"), Lit("b"), Lit("c"))
+    assert Either(Lit("a"), Lit("b"), Lit("c")).match("ac")
 
 def test_either_followed_by_literal_no_match():
     # /{a,b}c/ doesn't match "ax"
-    assert not Either(Lit("a"), Lit("b"), Lit("x"))
+    assert not Either(Lit("a"), Lit("b"), Lit("c")).match("ax")
 # [/keep]


### PR DESCRIPTION
These two tests produce fail even later in the chapter when the class Either is corrected, principally because they miss a `.match("ac")` and a `.match("ax")`, respectively.

```
def test_either_followed_by_literal_match():
    # /{a,b}c/ matches "ac"
    assert Either(Lit("a"), Lit("b"), Lit("c"))

def test_either_followed_by_literal_no_match():
    # /{a,b}c/ doesn't match "ax"
    assert not Either(Lit("a"), Lit("b"), Lit("x"))
```