### PR TITLE
Make caption consistent with the language

### DIFF
--- a/src/interp/index.md
+++ b/src/interp/index.md
@@ -142,7 +142,7 @@ until we reach an integer or some other value that doesn't require any further w
    slug="interp-recursive-evaluation"
    img="recursive_evaluation.svg"
    alt="Recursive evaluation of an expression tree"
-   caption="Recursively evaluating the expression `abs(1+2)`."
+   caption="Recursively evaluating the expression `["abs",["add",1,2]]`."
 %]
 
 With all of this code in place,


### PR DESCRIPTION
I found the text in the caption inconsistent with the little programming language we are trying to write a parser for. I propose to use the same language in the caption as well.