### PR TITLE
Fixed bug in VM debugger for adding/clearing breakpoints

### DIFF
--- a/src/debugger/vm_break.py
+++ b/src/debugger/vm_break.py
@@ -50,7 +50,7 @@ class VirtualMachineBreak(VirtualMachineExtend):
     # [add]
     def _do_add_breakpoint(self, addr):
         if self.ram[addr] == OPS["brk"]["code"]:
-            return
+            return True
         self.breaks[addr] = self.ram[addr]
         self.ram[addr] = OPS["brk"]["code"]
         return True
@@ -59,7 +59,7 @@ class VirtualMachineBreak(VirtualMachineExtend):
     # [clear]
     def _do_clear_breakpoint(self, addr):
         if self.ram[addr] != OPS["brk"]["code"]:
-            return
+            return True
         self.ram[addr] = self.breaks[addr]
         del self.breaks[addr]
         return True


### PR DESCRIPTION
If you try adding a breakpoint and this operation fails (because there is already a breakpoint at that address), the debugger will step to the next instruction, which seems to be unintended behaviour. The same happens for trying to clear a breakpoint at an address where there is no breakpoint. This happens because these two commands return None in case of failure, which interferes with the loop from `interact()` in `vm_extend.py` (the variable `interacting` becomes None, breaking the loop and allowing the VM to step to the next instruction).