### PR TITLE
Change "_require" to "_must" in build_time.py

### DIFF
--- a/src/build/build_time.py
+++ b/src/build/build_time.py
@@ -8,7 +8,7 @@ from build_better import BuildBetter
 class BuildTime(BuildBetter):
     def _check_keys(self, name, details):
         super()._check_keys(name, details)
-        self._require("time" in details, f"No time for {name}")
+        self._must("time" in details, f"No time for {name}")
 
     def _refresh(self, config, node, actions):
         assert node in config, f"Unknown node {node}"


### PR DESCRIPTION
BuildBetter class doesn't have "_require". I assume a call to "_must" was intended.