### PR TITLE
/viewer – Fix `Window` size bug 

### DIFF
--- a/src/viewer/cursor_const.py
+++ b/src/viewer/cursor_const.py
@@ -11,7 +11,7 @@ class Window:
         if size is None:
             self._size = (curses.LINES, curses.COLS)
         else:
-            self._size = size
+            self._size = [min(user_input, limit) for user_input, limit in zip(size, (curses.LINES, curses.COLS))]
 
     def size(self):
         return self._size

--- a/src/viewer/size_window.py
+++ b/src/viewer/size_window.py
@@ -1,7 +1,7 @@
 import curses
 import sys
 
-from util import open_log, log, make_lines, start
+from util import open_log, log, make_lines, start, ROW, COL
 
 # [window]
 class Window:
@@ -11,7 +11,8 @@ class Window:
             self._nrow = curses.LINES
             self._ncol = curses.COLS
         else:
-            self._nrow, self._ncol = size
+            self._nrow = min(size[ROW], curses.LINES)
+            self._ncol = min(size[COL], curses.COLS)
 
     def draw(self, lines):
         self._screen.erase()


### PR DESCRIPTION
The `Window` classes defined in both `src/viewer/size_window.py` and `src/viewer/cursor_const.py` accept user input to determine the size of the drawable area. If no input is given `curses.LINES` and `curses.COLS` are used instead. 

If the user unwittingly provides a size input which is larger than the available area **and** tries to draw into that area, the `curses` raises an error. Example (assuming 15 lines are actually available): 
```
$ python3 cursor_const.py 16 log.txt 20 15
Traceback (most recent call last):
  File "/Users/diyartaskiran/*/SDXPY/src/viewer/cursor_const.py", line 36, in <module>
    curses.wrapper(lambda stdscr: main(stdscr, size, lines))
  File "/Users/diyartaskiran/anaconda3/envs/softwareconstruction/lib/python3.11/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/diyartaskiran/*/SDXPY/src/viewer/cursor_const.py", line 36, in <lambda>
    curses.wrapper(lambda stdscr: main(stdscr, size, lines))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/diyartaskiran/*/SDXPY/src/viewer/cursor_const.py", line 28, in main
    window.draw(lines)
  File "/Users/diyartaskiran/*/SDXPY/src/viewer/cursor_const.py", line 23, in draw
    self._screen.addstr(y, 0, line[:self._size[COL]])
_curses.error: addwstr() returned ERR
```

In both classes, this is easily changed by accepting **at most** `curses.LINES` and `curses.COLS` as window size. 

Note: this issue may also extend into the `Window` classes defined in `src/undo`, but I have not been able to look into that yet. 