### PR TITLE
Fix building src/check

### DIFF
--- a/src/check/index.md
+++ b/src/check/index.md
@@ -127,7 +127,7 @@ and then calls itself once for each child to collect their children:
 
 When we run our function on this page:
 
-[% inc file="page.html" %]
+[% inc file="page.html" keep="content" %]
 
 it produces this output
 (which we print in sorted order to make things easier to find):

--- a/src/check/page.html
+++ b/src/check/page.html
@@ -1,3 +1,7 @@
+---
+disable: true
+---
+[content]
 <html>
   <head>
     <title>Software Design by Example</title>
@@ -11,3 +15,4 @@
     </ul>
   </body>
 </html>
+[/content]


### PR DESCRIPTION
Running `make build` complains about `@root/check/page//`.

I added a disable header to page.html and then conditionally included the content in index.md. It successfully built and the resulting docs/check/index.html looks the same (modulo build_date).