### PR TITLE
Update error message for assert_is_address in vm_base.py

### DIFF
--- a/src/debugger/vm_base.py
+++ b/src/debugger/vm_base.py
@@ -145,7 +145,7 @@ class VirtualMachineBase:
         assert 0 <= reg < len(self.reg), f"Invalid register {reg:06x}"
 
     def assert_is_address(self, addr):
-        assert 0 <= addr < len(self.ram), f"Invalid register {addr:06x}"
+        assert 0 <= addr < len(self.ram), f"Invalid address {addr:06x}"
 
     # [write]
     def write(self, *args):


### PR DESCRIPTION
Error message in assert_is_address says "Invalid register" when it should say "Invalid address".